### PR TITLE
Revise mocap interfaces

### DIFF
--- a/mocap_optitrack_client/include/MoCapNatNetClient/MoCapNatNetClient.h
+++ b/mocap_optitrack_client/include/MoCapNatNetClient/MoCapNatNetClient.h
@@ -62,7 +62,7 @@ public:
     // Setters
 
     //Methods to forward messages to the ROS2 system
-    void sendRigidBodyMessage(sRigidBodyData* bodies, int nRigidBodies);
+    void sendRigidBodyMessage(uint64_t cameraMidExposureTimestamp, sRigidBodyData* bodies, int nRigidBodies);
 
     
 };

--- a/mocap_optitrack_client/include/MoCapNatNetClient/MoCapNatNetClient.h
+++ b/mocap_optitrack_client/include/MoCapNatNetClient/MoCapNatNetClient.h
@@ -62,7 +62,7 @@ public:
     // Setters
 
     //Methods to forward messages to the ROS2 system
-    void sendRigidBodyMessage(uint64_t cameraMidExposureTimestamp, sRigidBodyData* bodies, int nRigidBodies);
+    void sendRigidBodyMessage(double cameraMidExposureSecsSinceEpoch, sRigidBodyData* bodies, int nRigidBodies);
 
     
 };

--- a/mocap_optitrack_client/include/MoCapPublisher/MoCapPublisher.h
+++ b/mocap_optitrack_client/include/MoCapPublisher/MoCapPublisher.h
@@ -27,7 +27,7 @@ public:
     MoCapPublisher();
 
     // Send methods
-    void sendRigidBodyMessage(sRigidBodyData* bodies_ptr, int nRigidBodies);
+    void sendRigidBodyMessage(uint64_t cameraMidExposureTimestamp, sRigidBodyData* bodies_ptr, int nRigidBodies);
  
     // Getters
     std::string getServerAddress();

--- a/mocap_optitrack_client/include/MoCapPublisher/MoCapPublisher.h
+++ b/mocap_optitrack_client/include/MoCapPublisher/MoCapPublisher.h
@@ -27,7 +27,7 @@ public:
     MoCapPublisher();
 
     // Send methods
-    void sendRigidBodyMessage(uint64_t cameraMidExposureTimestamp, sRigidBodyData* bodies_ptr, int nRigidBodies);
+    void sendRigidBodyMessage(double cameraMidExposureSecsSinceEpoch, sRigidBodyData* bodies_ptr, int nRigidBodies);
  
     // Getters
     std::string getServerAddress();

--- a/mocap_optitrack_client/src/MoCapNatNetClient.cpp
+++ b/mocap_optitrack_client/src/MoCapNatNetClient.cpp
@@ -177,6 +177,9 @@ void NATNET_CALLCONV dataFrameHandler(sFrameOfMocapData* data, void* pUserData)
     // Only recent versions of the Motive software in combination with ethernet camera systems support system latency measurement.
     // If it's unavailable (for example, with USB camera systems, or during playback), this field will be zero.
     const bool bSystemLatencyAvailable = data->CameraMidExposureTimestamp != 0;
+    // Client latency is defined as the sum of system latency and the transit time taken to relay the data to the NatNet client.
+    // This is the all-inclusive measurement (photons to client processing).
+    double clientLatencyMillisec;
     //
     if ( bSystemLatencyAvailable )
     {
@@ -189,7 +192,7 @@ void NATNET_CALLCONV dataFrameHandler(sFrameOfMocapData* data, void* pUserData)
 
         // Client latency is defined as the sum of system latency and the transit time taken to relay the data to the NatNet client.
         // This is the all-inclusive measurement (photons to client processing).
-        const double clientLatencyMillisec = pClient->SecondsSinceHostTimestamp( data->CameraMidExposureTimestamp ) * 1000.0;
+        clientLatencyMillisec = pClient->SecondsSinceHostTimestamp( data->CameraMidExposureTimestamp ) * 1000.0;
 
         // You could equivalently do the following (not accounting for time elapsed since we calculated transit latency above):
         //const double clientLatencyMillisec = systemLatencyMillisec + transitLatencyMillisec;
@@ -217,9 +220,15 @@ void NATNET_CALLCONV dataFrameHandler(sFrameOfMocapData* data, void* pUserData)
 	char szTimecode[128] = "";
     NatNet_TimecodeStringify( data->Timecode, data->TimecodeSubframe, szTimecode, 128 );
 	RCLCPP_DEBUG(pClient->getPublisher()->get_logger(), "Timecode : %s\n", szTimecode);
+
+    // Compute the UNIX time (in seconds) by checking the current clock time on the client machine and subtracting the total latency / delay
+    const double currentSecsSinceEpoch = pClient->getPublisher()->get_clock()->now().seconds();
+    const double cameraMidExposureSecsSinceEpoch = currentSecsSinceEpoch - (clientLatencyMillisec + transitLatencyMillisec) / 1000;
+    RCLCPP_DEBUG(pClient->getPublisher()->get_logger(), "Mid camera exposure seconds since epoch : %.2lf seconds\n", cameraMidExposureSecsSinceEpoch);
+
     //
 	// Rigid Bodies
-    pClient->sendRigidBodyMessage(data->CameraMidExposureTimestamp, data->RigidBodies, data->nRigidBodies);
+    pClient->sendRigidBodyMessage(cameraMidExposureSecsSinceEpoch, data->RigidBodies, data->nRigidBodies);
     //
     //NOTE : from below is just logging...
 	// Skeletons
@@ -322,9 +331,9 @@ void NATNET_CALLCONV dataFrameHandler(sFrameOfMocapData* data, void* pUserData)
 }
 
 // Method responsible of forwarding messages of rigid body data to the ROS2 publisher
-void MoCapNatNetClient::sendRigidBodyMessage(uint64_t cameraMidExposureTimestamp, sRigidBodyData* bodies, int nRigidBodies)
+void MoCapNatNetClient::sendRigidBodyMessage(double cameraMidExposureSecsSinceEpoch, sRigidBodyData* bodies, int nRigidBodies)
 {
-    this->moCapPublisher->sendRigidBodyMessage(cameraMidExposureTimestamp, bodies, nRigidBodies);
+    this->moCapPublisher->sendRigidBodyMessage(cameraMidExposureSecsSinceEpoch, bodies, nRigidBodies);
 }
 
 

--- a/mocap_optitrack_client/src/MoCapNatNetClient.cpp
+++ b/mocap_optitrack_client/src/MoCapNatNetClient.cpp
@@ -219,7 +219,7 @@ void NATNET_CALLCONV dataFrameHandler(sFrameOfMocapData* data, void* pUserData)
 	RCLCPP_DEBUG(pClient->getPublisher()->get_logger(), "Timecode : %s\n", szTimecode);
     //
 	// Rigid Bodies
-    pClient->sendRigidBodyMessage(data->RigidBodies, data->nRigidBodies);
+    pClient->sendRigidBodyMessage(data->CameraMidExposureTimestamp, data->RigidBodies, data->nRigidBodies);
     //
     //NOTE : from below is just logging...
 	// Skeletons
@@ -322,9 +322,9 @@ void NATNET_CALLCONV dataFrameHandler(sFrameOfMocapData* data, void* pUserData)
 }
 
 // Method responsible of forwarding messages of rigid body data to the ROS2 publisher
-void MoCapNatNetClient::sendRigidBodyMessage(sRigidBodyData* bodies, int nRigidBodies)
+void MoCapNatNetClient::sendRigidBodyMessage(uint64_t cameraMidExposureTimestamp, sRigidBodyData* bodies, int nRigidBodies)
 {
-    this->moCapPublisher->sendRigidBodyMessage(bodies, nRigidBodies);
+    this->moCapPublisher->sendRigidBodyMessage(cameraMidExposureTimestamp, bodies, nRigidBodies);
 }
 
 

--- a/mocap_optitrack_client/src/MoCapNatNetClient.cpp
+++ b/mocap_optitrack_client/src/MoCapNatNetClient.cpp
@@ -179,7 +179,7 @@ void NATNET_CALLCONV dataFrameHandler(sFrameOfMocapData* data, void* pUserData)
     const bool bSystemLatencyAvailable = data->CameraMidExposureTimestamp != 0;
     // Client latency is defined as the sum of system latency and the transit time taken to relay the data to the NatNet client.
     // This is the all-inclusive measurement (photons to client processing).
-    double clientLatencyMillisec;
+    double clientLatencyMillisec = transitLatencyMillisec;
     //
     if ( bSystemLatencyAvailable )
     {
@@ -223,7 +223,7 @@ void NATNET_CALLCONV dataFrameHandler(sFrameOfMocapData* data, void* pUserData)
 
     // Compute the UNIX time (in seconds) by checking the current clock time on the client machine and subtracting the total latency / delay
     const double currentSecsSinceEpoch = pClient->getPublisher()->get_clock()->now().seconds();
-    const double cameraMidExposureSecsSinceEpoch = currentSecsSinceEpoch - (clientLatencyMillisec + transitLatencyMillisec) / 1000;
+    const double cameraMidExposureSecsSinceEpoch = currentSecsSinceEpoch - clientLatencyMillisec / 1000;
     RCLCPP_DEBUG(pClient->getPublisher()->get_logger(), "Mid camera exposure seconds since epoch : %.2lf seconds\n", cameraMidExposureSecsSinceEpoch);
 
     //

--- a/mocap_optitrack_client/src/MoCapPublisher.cpp
+++ b/mocap_optitrack_client/src/MoCapPublisher.cpp
@@ -38,9 +38,6 @@ MoCapPublisher::MoCapPublisher(): Node("natnet_client")
   this->get_parameter("pub_topic", topic_);
   this->publisher_ = this->create_publisher<mocap_optitrack_interfaces::msg::RigidBodyArray>(topic_.c_str(), 10);
   //
-  //Get the current time for the timestamp of the messages
-  this->t_start = high_resolution_clock::now();//get the current time
-  //
   //Just for testing purposes send make messages every 500ms
   //this->timer_ = this->create_wall_timer(500ms, std::bind(&MoCapPublisher::sendFakeMessage, this));
   //
@@ -54,7 +51,7 @@ MoCapPublisher::MoCapPublisher(): Node("natnet_client")
 }
 
 // Method that send over the ROS network the data of a rigid body
-void MoCapPublisher::sendRigidBodyMessage(sRigidBodyData* bodies_ptr, int nRigidBodies)
+void MoCapPublisher::sendRigidBodyMessage(uint64_t cameraMidExposureTimestamp, sRigidBodyData* bodies_ptr, int nRigidBodies)
 {
   std::vector<sRigidBodyData> bodies;
   for(int i=0; i < nRigidBodies; i++) 
@@ -65,9 +62,15 @@ void MoCapPublisher::sendRigidBodyMessage(sRigidBodyData* bodies_ptr, int nRigid
   // sort rigid bodies by their id
   std::sort(bodies.begin(), bodies.end(), cmpRigidBodyId);
 
+  // cameraMidExposureTimestamp as <std::time_t> object
+  // using time_point = std::chrono::system_clock::time_point;
+  // time_point cameraMidExposureTimepoint{std::chrono::duration_cast<time_point::duration>(std::chrono::nanoseconds(cameraMidExposureTimestamp))};
+  // std::time_t cameraMidExposureTime = std::chrono::system_clock::to_time_t(cameraMidExposureTimepoint);
+
   //Instanciate variables
   mocap_optitrack_interfaces::msg::RigidBodyArray msg;
-  high_resolution_clock::time_point t_current;
+  msg.header.stamp = rclcpp::Time(cameraMidExposureTimestamp);
+
   // Log
   RCLCPP_INFO(get_logger(), "Sending message containing %d Rigid Bodies.\n\n", nRigidBodies);
   // Loop over all the rigid bodies
@@ -86,6 +89,7 @@ void MoCapPublisher::sendRigidBodyMessage(sRigidBodyData* bodies_ptr, int nRigid
       //
       //Create the rigid body message
       mocap_optitrack_interfaces::msg::RigidBody rb;
+      rb.header.stamp = rclcpp::Time(cameraMidExposureTimestamp);
       rb.id = bodies[i].ID;
       rb.valid =  bodies[i].params & 0x01;
       rb.mean_error = bodies[i].MeanError;
@@ -97,13 +101,7 @@ void MoCapPublisher::sendRigidBodyMessage(sRigidBodyData* bodies_ptr, int nRigid
       rb.pose_stamped.pose.orientation.z = bodies[i].qz;
       rb.pose_stamped.pose.orientation.w = bodies[i].qw;
       //
-      // Add the time stamp information both in seconds and nanoseconds
-      t_current = high_resolution_clock::now();
-      auto time_span_s  = duration_cast<seconds>(t_current - this->t_start);
-      auto time_span_ns = duration_cast<nanoseconds>(t_current - this->t_start);
-      //
-      rb.pose_stamped.header.stamp.sec = time_span_s.count();
-      rb.pose_stamped.header.stamp.nanosec = time_span_ns.count();
+      rb.pose_stamped.header.stamp = rclcpp::Time(cameraMidExposureTimestamp);
       //
       // Add the current rigid body to the array of rigid bodies
       msg.rigid_bodies.push_back(rb);
@@ -132,7 +130,7 @@ void MoCapPublisher::sendFakeMessage()
       bodies[i].params = 1;
     }
     //Send the message
-    this->sendRigidBodyMessage(bodies, nRigidBodies);
+    this->sendRigidBodyMessage(time(NULL), bodies, nRigidBodies);
 
     //Free the rigid bodies
     free(bodies);

--- a/mocap_optitrack_interfaces/CMakeLists.txt
+++ b/mocap_optitrack_interfaces/CMakeLists.txt
@@ -27,8 +27,9 @@ find_package(std_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/RigidBody.msg"
   "msg/RigidBodyArray.msg"
-  "msg/Configuration.msg"
-  "msg/ConfigurationArray.msg"
+  "msg/CcDeltaConfiguration.msg"
+  "msg/PccDeltaConfiguration.msg"
+  "msg/PlanarCsConfiguration.msg"
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs
  )
 

--- a/mocap_optitrack_interfaces/msg/CcDeltaConfiguration.msg
+++ b/mocap_optitrack_interfaces/msg/CcDeltaConfiguration.msg
@@ -1,0 +1,6 @@
+std_msgs/Header header
+
+#Message to send the configuration of a CC segment
+float64 delta_x
+float64 delta_y
+float64 delta_l

--- a/mocap_optitrack_interfaces/msg/Configuration.msg
+++ b/mocap_optitrack_interfaces/msg/Configuration.msg
@@ -1,4 +1,0 @@
-#Message to send the configuration of a PCC segment
-float64 delta_x
-float64 delta_y
-float64 delta_l

--- a/mocap_optitrack_interfaces/msg/ConfigurationArray.msg
+++ b/mocap_optitrack_interfaces/msg/ConfigurationArray.msg
@@ -1,2 +1,0 @@
-#Array of configuration vectors
-Configuration[] configurations

--- a/mocap_optitrack_interfaces/msg/PccDeltaConfiguration.msg
+++ b/mocap_optitrack_interfaces/msg/PccDeltaConfiguration.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+
+# Array of constant curvature configuration vectors
+CcDeltaConfiguration[] segment_configurations

--- a/mocap_optitrack_interfaces/msg/PlanarCsConfiguration.msg
+++ b/mocap_optitrack_interfaces/msg/PlanarCsConfiguration.msg
@@ -1,0 +1,6 @@
+std_msgs/Header header
+
+#Message to send the configuration of a CC segment
+float64 kappa_b  # bending strain
+float64 sigma_sh  # shear strain
+float64 sigma_a  # axial / elongation strain

--- a/mocap_optitrack_interfaces/msg/RigidBody.msg
+++ b/mocap_optitrack_interfaces/msg/RigidBody.msg
@@ -1,3 +1,5 @@
+std_msgs/Header header
+
 # Message for a RigidBody of the NatNet server
 # Unique ID of the RigidBody, assigned by the the server
 int64 id

--- a/mocap_optitrack_interfaces/msg/RigidBodyArray.msg
+++ b/mocap_optitrack_interfaces/msg/RigidBodyArray.msg
@@ -1,2 +1,4 @@
-#Array of rigid bodies
+std_msgs/Header header
+
+# Array of rigid bodies
 RigidBody[] rigid_bodies

--- a/mocap_optitrack_inv_kin/include/InverseKinematicsNode.h
+++ b/mocap_optitrack_inv_kin/include/InverseKinematicsNode.h
@@ -2,7 +2,7 @@
 #define INVERSEKINEMATICSNODE_H
 
 #include "rclcpp/rclcpp.hpp"
-#include "mocap_optitrack_interfaces/msg/configuration_array.hpp"
+#include "mocap_optitrack_interfaces/msg/pcc_delta_configuration.hpp"
 #include "mocap_optitrack_interfaces/msg/rigid_body_array.hpp"
 #include <stdio.h>
 
@@ -19,7 +19,7 @@ private:
 
     //Attributes
     rclcpp::Subscription<mocap_optitrack_interfaces::msg::RigidBodyArray>::SharedPtr subscription_;
-    rclcpp::Publisher<mocap_optitrack_interfaces::msg::ConfigurationArray>::SharedPtr publisher_;
+    rclcpp::Publisher<mocap_optitrack_interfaces::msg::PccDeltaConfiguration>::SharedPtr publisher_;
     std::unique_ptr<InverseKinematics> ik;
 
     //DA RIMUOVERE

--- a/mocap_optitrack_inv_kin/src/InverseKinematicsNode.cpp
+++ b/mocap_optitrack_inv_kin/src/InverseKinematicsNode.cpp
@@ -43,7 +43,7 @@ InverseKinematicsNode::InverseKinematicsNode(): Node("inverse_kinematics")
     this->get_parameter("pub_topic", pub_topic_);
     char* pub_topic = (char*) malloc(pub_topic_.length()*sizeof(char));
     strcpy(pub_topic, pub_topic_.c_str());
-    this->publisher_ = this->create_publisher<mocap_optitrack_interfaces::msg::ConfigurationArray>(pub_topic, 10);
+    this->publisher_ = this->create_publisher<mocap_optitrack_interfaces::msg::PccDeltaConfiguration>(pub_topic, 10);
     //
     //Create the node responsible of handling the inverse kinematics
     bool IK_type = false;
@@ -80,15 +80,17 @@ void InverseKinematicsNode::rigid_body_topic_callback(const mocap_optitrack_inte
     std::cout << q << std::endl;
     //TODO: must generalize to handle also the 2D case. For the case of NoElongation delta_l is just 0.
     //Create the message of configurations and publish it
-    mocap_optitrack_interfaces::msg::ConfigurationArray q_msg;
+    mocap_optitrack_interfaces::msg::PccDeltaConfiguration q_msg;
+    q_msg.header.stamp = msg->header.stamp;
     int msg_size = (int) q.rows()/3;
-    q_msg.configurations = std::vector<mocap_optitrack_interfaces::msg::Configuration>(msg_size);
+    q_msg.segment_configurations = std::vector<mocap_optitrack_interfaces::msg::CcDeltaConfiguration>(msg_size);
     int i= 0, k = 0;
     for (; i < msg_size; i++)
     {
-        q_msg.configurations[i].delta_x = q(k);
-        q_msg.configurations[i].delta_y = q(k+1);
-        q_msg.configurations[i].delta_l = q(k+2);
+        q_msg.segment_configurations[i].header.stamp = msg->header.stamp;
+        q_msg.segment_configurations[i].delta_x = q(k);
+        q_msg.segment_configurations[i].delta_y = q(k+1);
+        q_msg.segment_configurations[i].delta_l = q(k+2);
         k = k+3;
     }
     //Publish the message

--- a/mocap_optitrack_w2b/src/WorldToBase.cpp
+++ b/mocap_optitrack_w2b/src/WorldToBase.cpp
@@ -90,6 +90,7 @@ void WorldToBase::transformPoseAndSend(const mocap_optitrack_interfaces::msg::Ri
   //
   Eigen::Vector4f xi_0_B; // vector that represents the unit quaternion of the rigid body in the robot base frame
   mocap_optitrack_interfaces::msg::RigidBodyArray msg_r;//message to send over the ROS2 network with the modified poses
+  msg_r.header = msg->header;
   //
   /* Get the pose of the base of the robot recorded by the motion capture system */
   for (i = 0; i < nRB; i++)
@@ -164,6 +165,8 @@ void WorldToBase::transformPoseAndSend(const mocap_optitrack_interfaces::msg::Ri
       //
       /* Save the tranformed pose in the new message*/
       mocap_optitrack_interfaces::msg::RigidBody rb = msg->rigid_bodies[i];
+      // Store the header
+      rb.pose_stamped.header = msg->rigid_bodies[i].pose_stamped.header;
       // Store the position
       rb.pose_stamped.pose.position.x = T_0_B(0, 3);
       rb.pose_stamped.pose.position.y = T_0_B(1, 3);


### PR DESCRIPTION
Thie PR includes multiple improvements:

- use the time of the camera mid exposure to stamp the ROS2 messages. This will allow us to track any delays and latencies through the entire processing pipeline
- Rename `Configuration` and `ConfigurationArray` messages to `CcDeltaConfiguration` and `PccDeltaConfiguration` respectively
- Stamp all the messages (i.e. also the configuration, the rigid body, the base frame messages etc.)