### PR TITLE
Start motive recording

### DIFF
--- a/mocap_optitrack_client/config/natnetclient.yaml
+++ b/mocap_optitrack_client/config/natnetclient.yaml
@@ -23,7 +23,7 @@ natnet_client:
     # Topic where data is published
     pub_topic: "mocap_rigid_bodies"
     # wether to start the recording in Motive
-    start_recording: true
+    record: true
     # by default (null) the date and time will be used as name of the take
     take_name: null
   

--- a/mocap_optitrack_client/config/natnetclient.yaml
+++ b/mocap_optitrack_client/config/natnetclient.yaml
@@ -24,6 +24,6 @@ natnet_client:
     pub_topic: "mocap_rigid_bodies"
     # wether to start the recording in Motive
     record: true
-    # by default (null) the date and time will be used as name of the take
-    take_name: null
+    # by default (with an empty string) the date and time will be used as name of the take
+    take_name: ""
   

--- a/mocap_optitrack_client/config/natnetclient.yaml
+++ b/mocap_optitrack_client/config/natnetclient.yaml
@@ -22,3 +22,8 @@ natnet_client:
     server_data_port: 1511 #default value: 1511
     # Topic where data is published
     pub_topic: "mocap_rigid_bodies"
+    # wether to start the recording in Motive
+    start_recording: true
+    # by default (null) the date and time will be used as name of the take
+    take_name: null
+  

--- a/mocap_optitrack_client/include/MoCapNatNetClient/MoCapNatNetClient.h
+++ b/mocap_optitrack_client/include/MoCapNatNetClient/MoCapNatNetClient.h
@@ -27,6 +27,7 @@ private:
     MoCapPublisher* moCapPublisher;
     //const char* server_address;
     //const char* multicast_address;
+    bool recordingStarted_ = false;
     
     
     // Method to get the data description from the server
@@ -60,6 +61,10 @@ public:
     int getAnalogSamplesPerMocapFrame();
     MoCapPublisher* getPublisher();//returns the Ros2 publisher
     // Setters
+
+    // methods to manage the recording
+    bool startRecording();
+    bool stopRecording();
 
     //Methods to forward messages to the ROS2 system
     void sendRigidBodyMessage(sRigidBodyData* bodies, int nRigidBodies);

--- a/mocap_optitrack_client/include/MoCapNatNetClient/MoCapNatNetClient.h
+++ b/mocap_optitrack_client/include/MoCapNatNetClient/MoCapNatNetClient.h
@@ -61,6 +61,7 @@ public:
     int getAnalogSamplesPerMocapFrame();
     MoCapPublisher* getPublisher();//returns the Ros2 publisher
     // Setters
+    bool setTakeName(std::string takeName);
 
     // methods to manage the recording
     bool startRecording();

--- a/mocap_optitrack_client/include/MoCapPublisher/MoCapPublisher.h
+++ b/mocap_optitrack_client/include/MoCapPublisher/MoCapPublisher.h
@@ -36,6 +36,7 @@ public:
     uint16_t getServerCommandPort();
     uint16_t getServerDataPort();
     bool isRecordingRequested();
+    std::string getTakeName();
     
     // Setters
 

--- a/mocap_optitrack_client/include/MoCapPublisher/MoCapPublisher.h
+++ b/mocap_optitrack_client/include/MoCapPublisher/MoCapPublisher.h
@@ -35,6 +35,7 @@ public:
     std::string getMulticastAddress();
     uint16_t getServerCommandPort();
     uint16_t getServerDataPort();
+    bool isRecordingRequested();
     
     // Setters
 

--- a/mocap_optitrack_client/src/MoCapNatNetClient.cpp
+++ b/mocap_optitrack_client/src/MoCapNatNetClient.cpp
@@ -111,6 +111,11 @@ int MoCapNatNetClient::connect()
         RCLCPP_ERROR(this->moCapPublisher->get_logger(), "Error getting Analog frame rate.\n");
     }
 
+    std::string takeName = moCapPublisher->getTakeName();
+    if (!takeName.empty()) {
+        this->setTakeName(takeName);
+    }
+
     // start recording if requested
     this->recordingStarted_ = false;
     if (moCapPublisher->isRecordingRequested()) {
@@ -500,7 +505,7 @@ bool MoCapNatNetClient::startRecording()
     ret = this->SendMessageAndWait("StartRecording", &pResult, &nBytes);
 
     if (ret != ErrorCode_OK) {
-        RCLCPP_ERROR(this->moCapPublisher->get_logger(), "Recording could not be started as the request was responded with error code %d", ret);
+        RCLCPP_ERROR(this->moCapPublisher->get_logger(), "Recording could not be started as the request returned error code %d", ret);
     }
 
     return ret == ErrorCode_OK;
@@ -514,7 +519,21 @@ bool MoCapNatNetClient::stopRecording()
     ret = this->SendMessageAndWait("StopRecording", &pResult, &nBytes);
 
     if (ret != ErrorCode_OK) {
-        RCLCPP_ERROR(this->moCapPublisher->get_logger(), "Recording could not be stopped as the request was responded with error code %d", ret);
+        RCLCPP_ERROR(this->moCapPublisher->get_logger(), "Recording could not be stopped as the request returned error code %d", ret);
+    }
+
+    return ret == ErrorCode_OK;
+}
+
+bool MoCapNatNetClient::setTakeName(std::string takeName)
+{
+    ErrorCode ret = ErrorCode_OK;
+    void* pResult;
+    int nBytes = 0;
+    ret = this->SendMessageAndWait(("SetRecordTakeName," + takeName).c_str(), &pResult, &nBytes);
+
+    if (ret != ErrorCode_OK) {
+        RCLCPP_ERROR(this->moCapPublisher->get_logger(), "Could not set recording take name as the request returned error code %d", ret);
     }
 
     return ret == ErrorCode_OK;

--- a/mocap_optitrack_client/src/MoCapNatNetClient.cpp
+++ b/mocap_optitrack_client/src/MoCapNatNetClient.cpp
@@ -35,7 +35,7 @@ MoCapNatNetClient::MoCapNatNetClient(MoCapPublisher* _moCapPublisher)
     this->SetFrameReceivedCallback( dataFrameHandler, this );
 }
 
-// Distructor
+// Destructor
 MoCapNatNetClient::~MoCapNatNetClient()
 {
     if ( this->pDataDefs )

--- a/mocap_optitrack_client/src/MoCapPublisher.cpp
+++ b/mocap_optitrack_client/src/MoCapPublisher.cpp
@@ -32,8 +32,8 @@ MoCapPublisher::MoCapPublisher(): Node("natnet_client")
   this->declare_parameter<uint16_t>("server_command_port", 1510);
   this->declare_parameter<uint16_t>("server_data_port", 1511);
   this->declare_parameter<std::string>("pub_topic", "rigid_body_topic");
-  this->declare_parameter<bool>("start_recording", true);
-  this->declare_parameter<std::string>("take_name", NULL);
+  this->declare_parameter<bool>("record", true);
+  // this->declare_parameter<std::string>("take_name", NULL);
   //
   //Create the publisher
   std::string topic_;
@@ -175,6 +175,12 @@ uint16_t MoCapPublisher::getServerDataPort()
   return port_;
 }
 
+bool MoCapPublisher::isRecordingRequested()
+{
+  bool record_;
+  this->get_parameter("record", record_);
+  return record_;
+}
 
 // Main
 int main(int argc, char ** argv)
@@ -197,6 +203,8 @@ int main(int argc, char ** argv)
   }
   // Ready to receive marker stream
   rclcpp::spin(mocapPub);
+  // disconnect the clinet
+  c->disconnect();
   // Delete all the objects created
   delete c;
   rclcpp::shutdown();//delete the ROS2 nodes

--- a/mocap_optitrack_client/src/MoCapPublisher.cpp
+++ b/mocap_optitrack_client/src/MoCapPublisher.cpp
@@ -33,7 +33,7 @@ MoCapPublisher::MoCapPublisher(): Node("natnet_client")
   this->declare_parameter<uint16_t>("server_data_port", 1511);
   this->declare_parameter<std::string>("pub_topic", "rigid_body_topic");
   this->declare_parameter<bool>("record", true);
-  // this->declare_parameter<std::string>("take_name", NULL);
+  this->declare_parameter<std::string>("take_name", "");
   //
   //Create the publisher
   std::string topic_;
@@ -180,6 +180,29 @@ bool MoCapPublisher::isRecordingRequested()
   bool record_;
   this->get_parameter("record", record_);
   return record_;
+}
+
+std::string MoCapPublisher::getTakeName()
+{
+  std::string takeName_;
+  this->get_parameter("take_name", takeName_);
+
+  if (takeName_.empty())
+  {
+    // set take name to the current date and time in the format
+    time_t curr_time;
+    tm * curr_tm;
+    char datetime_string[100];
+    
+    time(&curr_time);
+    curr_tm = localtime(&curr_time);
+
+    // "take_20230101_235959"
+    strftime(datetime_string, 50, "take_%Y%m%d_%H%M%S", curr_tm);
+    takeName_ = std::string(datetime_string);
+  }
+
+  return takeName_;
 }
 
 // Main

--- a/mocap_optitrack_client/src/MoCapPublisher.cpp
+++ b/mocap_optitrack_client/src/MoCapPublisher.cpp
@@ -32,6 +32,8 @@ MoCapPublisher::MoCapPublisher(): Node("natnet_client")
   this->declare_parameter<uint16_t>("server_command_port", 1510);
   this->declare_parameter<uint16_t>("server_data_port", 1511);
   this->declare_parameter<std::string>("pub_topic", "rigid_body_topic");
+  this->declare_parameter<bool>("start_recording", true);
+  this->declare_parameter<std::string>("take_name", NULL);
   //
   //Create the publisher
   std::string topic_;


### PR DESCRIPTION
If requested via ROS params, automatically start a motive recording. This gives us clean data of the MoCap information for later plotting / processing.